### PR TITLE
Include Gemoji tags in addition to aliases

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -181,6 +181,16 @@ func init() {
 			}
 			aliasMap[a], aliasPairs = i, append(aliasPairs, ":"+a+":", e.Emoji)
 		}
+		// in addition to aliases, also include tags
+		for _, t := range e.Tags {
+			if t == "" {
+				continue
+			}
+			// but only if it doesn't already exist, e.g. "angry"
+			if _, ok := aliasMap[t]; !ok {
+				aliasMap[t], aliasPairs = i, append(aliasPairs, ":"+t+":", e.Emoji)
+			}
+		}
 	}
 	// process emoticons
 	reVals := make([]string, 0)

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -57,7 +57,7 @@ func TestReplacers(t *testing.T) {
 		v, exp string
 	}{
 		{ReplaceCodes, ":thumbsup: +1 for \U0001f37a! 🍺 \U0001f44d", ":thumbsup: +1 for :beer:! :beer: :+1:"},
-		{ReplaceAliases, ":thumbsup: +1 :+1: :beer:", "\U0001f44d +1 \U0001f44d \U0001f37a"},
+		{ReplaceAliases, ":thumbsup: +1 :+1: :beer: :lol:", "\U0001f44d +1 \U0001f44d \U0001f37a \U0001f923"},
 
 		{ReplaceEmoticonsWithCodes, "foobar", "foobar"},
 		{ReplaceEmoticonsWithCodes, " foobar", " foobar"},


### PR DESCRIPTION
This adds supports for say `:lol:` where it's in Gemoji's data as tags. See #2.

Unfortunately, there are things such as `:angry:` where it's defined in both aliases and tags. In these cases, we'll use the aliases.