### PR TITLE
Allow adding additional aliases to existing emoji aliases

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -320,3 +320,20 @@ var emoticonMap = map[string][]string{
 
 // cleanRE is matches non alpha characters.
 var cleanRE = regexp.MustCompile(`(?i)[^a-z]`)
+
+// AddAlias adds the specified emoji alias
+func AddAlias(alias string, dest string) error {
+	if strings.HasPrefix(alias, ":") && strings.HasSuffix(alias, ":") {
+		alias = alias[1 : len(alias)-1]
+	}
+	if strings.HasPrefix(dest, ":") && strings.HasSuffix(dest, ":") {
+		dest = dest[1 : len(dest)-1]
+	}
+
+	if _, ok := aliasMap[dest]; !ok {
+		return fmt.Errorf("destination emoji alias does not exist")
+	}
+
+	aliasMap[alias] = aliasMap[dest]
+	return nil
+}

--- a/emoji.go
+++ b/emoji.go
@@ -145,6 +145,7 @@ var (
 	codeMap map[string]int
 	// aliasMap provides a map of the alias to its emoji data.
 	aliasMap map[string]int
+	aliasPairs []string
 	// codeReplacer is the string replacer for emoji codes.
 	codeReplacer *strings.Replacer
 	// aliasReplacer is the string replacer for emoji aliases.
@@ -168,7 +169,7 @@ func init() {
 	emoticonCodeMap = make(map[string]string)
 	emoticonAliasMap = make(map[string]string)
 	// process emoji codes and aliases
-	var codePairs, aliasPairs []string
+	var codePairs []string
 	for i, e := range data {
 		if e.Emoji == "" || len(e.Aliases) == 0 {
 			continue
@@ -334,6 +335,11 @@ func AddAlias(alias string, dest string) error {
 		return fmt.Errorf("destination emoji alias does not exist")
 	}
 
-	aliasMap[alias] = aliasMap[dest]
+	data := Gemoji()
+	idx := aliasMap[dest]
+	aliasMap[alias], aliasPairs = idx, append(aliasPairs, ":"+alias+":", data[idx].Emoji)
+
+	// update replacer with latest
+	aliasReplacer = strings.NewReplacer(aliasPairs...)
 	return nil
 }

--- a/example_test.go
+++ b/example_test.go
@@ -24,12 +24,16 @@ func Example() {
 	s2 := emoji.ReplaceEmoticonsWithCodes(":-) :D >:(")
 	fmt.Println(":-) :D >:(", "--", s2)
 
+	s3 := emoji.ReplaceAliases("new alias :rolling_on_the_floor_laughing: works")
+	fmt.Println(s3)
+
 	// Output:
 	// :-) -- 🙂
 	// :-) -- 🙂
 	// 🤣
 	// :-) :D >:( -- :slightly_smiling_face: :smile: :angry:
 	// :-) :D >:( -- 🙂 😄 😠
+	// new alias 🤣 works
 }
 
 func ExampleSkinTone() {

--- a/example_test.go
+++ b/example_test.go
@@ -14,6 +14,10 @@ func Example() {
 	e2 := emoji.FromAlias("slightly_smiling_face")
 	fmt.Println(":-)", "--", e2.Emoji)
 
+	emoji.AddAlias(":rolling_on_the_floor_laughing:", ":rofl:")
+	e3 := emoji.FromAlias("rolling_on_the_floor_laughing")
+	fmt.Println(e3.Emoji)
+
 	s1 := emoji.ReplaceEmoticonsWithAliases(":-) :D >:(")
 	fmt.Println(":-) :D >:(", "--", s1)
 
@@ -23,6 +27,7 @@ func Example() {
 	// Output:
 	// :-) -- 🙂
 	// :-) -- 🙂
+	// 🤣
 	// :-) :D >:( -- :slightly_smiling_face: :smile: :angry:
 	// :-) :D >:( -- 🙂 😄 😠
 }


### PR DESCRIPTION
Fixes #2.

So from the calling part, it can call `emoji.AddAlias()` and map new aliases to existing emoji aliases. For example, `rolling_on_the_floor_laughing` (🤣) to `rofl` as well as `my_custom_emoji_alias_name` to `white_check_mark` (✅).