### PR TITLE
Load Gemoji data set once and initialize maps & replacers on demand

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 //go:generate go run gen.go
@@ -146,6 +147,9 @@ const (
 )
 
 var (
+	emojiInitOnce sync.Once
+	emojiData     []Emoji
+
 	// codeMap provides a map of the emoji unicode code to its emoji data.
 	codeMap map[string]int
 	// aliasMap provides a map of the alias to its emoji data.
@@ -166,7 +170,7 @@ var (
 	emoticonAliasMap map[string]string
 )
 
-func init() {
+func initEmoji() {
 	data := Gemoji()
 	// initialize
 	codeMap = make(map[string]int, len(data))
@@ -214,16 +218,18 @@ func init() {
 	codeReplacer = strings.NewReplacer(codePairs...)
 	aliasReplacer = strings.NewReplacer(aliasPairs...)
 	aliasEmoticonReplacer = strings.NewReplacer(aliasEmoticonPairs...)
+	emojiData = data
 }
 
 // FromCode retrieves the emoji data based on the provided unicode code (ie,
 // "\u2618" will return the Gemoji data for "shamrock").
 func FromCode(code string) *Emoji {
+	emojiInitOnce.Do(initEmoji)
 	i, ok := codeMap[code]
 	if !ok {
 		return nil
 	}
-	data := Gemoji()
+	data := emojiData
 	return &data[i]
 }
 
@@ -231,6 +237,7 @@ func FromCode(code string) *Emoji {
 // "alias" or ":alias:" (ie, "shamrock" or ":shamrock:" will return the Gemoji
 // data for "shamrock").
 func FromAlias(alias string) *Emoji {
+	emojiInitOnce.Do(initEmoji)
 	if strings.HasPrefix(alias, ":") && strings.HasSuffix(alias, ":") {
 		alias = alias[1 : len(alias)-1]
 	}
@@ -245,7 +252,7 @@ func FromAlias(alias string) *Emoji {
 	if !ok {
 		return nil
 	}
-	data := Gemoji()
+	data := emojiData
 	if tone != Neutral {
 		modifiedEmoji := data[i]
 		tonedString := modifiedEmoji.Tone(tone)
@@ -258,6 +265,7 @@ func FromAlias(alias string) *Emoji {
 // FromEmoticon retrieves the emoji data based on the provided emoticon (ie,
 // ":o)" will return the Gemoji data for "monkey face").
 func FromEmoticon(emoticon string) *Emoji {
+	emojiInitOnce.Do(initEmoji)
 	alias, ok := emoticonAliasMap[emoticon]
 	if !ok {
 		return nil
@@ -269,18 +277,21 @@ func FromEmoticon(emoticon string) *Emoji {
 // alias (in the form of ":alias:") (ie, "\u2618" will be converted to
 // ":shamrock:").
 func ReplaceCodes(s string) string {
+	emojiInitOnce.Do(initEmoji)
 	return codeReplacer.Replace(s)
 }
 
 // ReplaceAliases replaces all aliases of the form ":alias:" with its
 // corresponding unicode value.
 func ReplaceAliases(s string) string {
+	emojiInitOnce.Do(initEmoji)
 	return aliasReplacer.Replace(s)
 }
 
 // emoticonReplacer replaces all matched emoticon strings in s with the its
 // corresponding map'd value in repl.
 func emoticonReplacer(s string, repl map[string]string) string {
+	emojiInitOnce.Do(initEmoji)
 	matches := emoticonRE.FindAllStringSubmatchIndex(s, -1)
 	// bail if no matches
 	if len(matches) == 0 {
@@ -306,6 +317,7 @@ func emoticonReplacer(s string, repl map[string]string) string {
 // corresponding emoji code (ie, the monkey face emoticon ":o)" will be
 // replaced with "\U0001f435").
 func ReplaceEmoticonsWithCodes(s string) string {
+	emojiInitOnce.Do(initEmoji)
 	return emoticonReplacer(s, emoticonCodeMap)
 }
 
@@ -313,6 +325,7 @@ func ReplaceEmoticonsWithCodes(s string) string {
 // the first corresponding emoji alias (in the form of :alias:) (ie, the monkey
 // face emoticon ":o)" will be replaced with ":monkey_face:").
 func ReplaceEmoticonsWithAliases(s string) string {
+	emojiInitOnce.Do(initEmoji)
 	return emoticonReplacer(s, emoticonAliasMap)
 }
 
@@ -320,6 +333,7 @@ func ReplaceEmoticonsWithAliases(s string) string {
 // :alias:) with its corresponding emoticon (ie, :D, :p, etc) (ie, the alias
 // ":monkey_face:" will be replaced with ":o)").
 func ReplaceAliasesWithEmoticons(s string) string {
+	emojiInitOnce.Do(initEmoji)
 	return aliasEmoticonReplacer.Replace(s)
 }
 


### PR DESCRIPTION
We load the Gemoji data set once and reuse that. This reduces memory allocations for example when making multiple calls to FromAlias() or FromCode().

Also, by initializing maps & replacers when needed, we allow the use of other functions such as ParseSkinTone() without having to load the Gemoji data set and the various maps & replacers.